### PR TITLE
Add setuptools installer and relax dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 cross_validation/cafe_faces/
 .ipynb_checkpoints/
 .pytest_cache/
+*.egg-info

--- a/README.md
+++ b/README.md
@@ -33,9 +33,7 @@ conda env create -f environment.yml -n plda  # "plda" is the environment name.
 __Usage__
 1. If you have one, 
     activate your conda envrionment with `conda activate plda`.
-2. Move this repository to the appropriate directory.
-   This might be a modules directory in your project or 
-    the same directory as the file importing this code.
+2. Install `plda` as a package into the environment with `pip install .` (path . should point to this repository on your filesystem)
 3. Add `import plda` to your code.
 4. See the demo below on how to use the actual model code.
 5. When you are all done,

--- a/environment.yml
+++ b/environment.yml
@@ -1,10 +1,10 @@
 dependencies:
-- python=3.5  # Necessary for plda.
-- numpy=1.14.2  # Necessary for plda.
-- scipy=1.0.1  # Necessary for plda.
-- scikit-learn=0.19.1  # Necessary for plda.
-- pytest=3.6.2  # Recommended for testing.
-- pycodestyle=2.4.0  # Recommended for contributing.
-- matplotlib=2.2.2  # Optional.
-- nb_conda=2.2.1  # Optional.
-- jupyter=1.0.0  # Optional.
+- python~=3.5  # Necessary for plda.
+- numpy~=1.14.2  # Necessary for plda.
+- scipy~=1.0.1  # Necessary for plda.
+- scikit-learn~=0.19.1  # Necessary for plda.
+- pytest~=3.6.2  # Recommended for testing.
+- pycodestyle~=2.4.0  # Recommended for contributing.
+- matplotlib~=2.2.2  # Optional.
+- nb_conda~=2.2.1  # Optional.
+- jupyter~=1.0.0  # Optional.

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,18 @@
+import setuptools
+
+with open("README.md") as f:
+    readmefile_contents = f.read()
+
+setuptools.setup(
+    name="plda",
+    version="0.1.0",
+    description="Probabilistic Linear Discriminant Analysis & classification",
+    author="Ravi Sojitra",
+    long_description=readmefile_contents,
+    long_description_content_type="text/markdown",
+    license="Apache 2.0",
+    python_requires=">= 3.5.*",
+    packages=[
+        "plda",
+    ],
+)


### PR DESCRIPTION
With this, one could install plda by doing `pip install ./plda`.

The pytest suite ran successfully but I had to first reduce tolerance from `1e-8` to `1e-6` on lines 150 and 162 of `tests/test_optimizer/test_optimizer_units.py`